### PR TITLE
feat: enhance model detection for OpenAI compatibility and environmen…

### DIFF
--- a/src/mcptube/config.py
+++ b/src/mcptube/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     port: int = 9093
 
     # LLM (BYOK — used in CLI mode, wired up later)
-    default_model: str = "gpt-4o"
+    default_model: str = "gpt-4o"  # Can be overridden via MCPTUBE_DEFAULT_MODEL env var
 
     @model_validator(mode="after")
     def _set_defaults(self) -> "Settings":

--- a/src/mcptube/llm.py
+++ b/src/mcptube/llm.py
@@ -124,12 +124,45 @@ class LLMClient:
             raise LLMError(f"LLM request failed ({self._model}): {e}") from e
 
     def _detect_model(self) -> str:
-        """Auto-detect the best available model from environment keys."""
+        """Auto-detect the best available model from environment keys.
+        
+        Priority order:
+        1. Model passed to constructor
+        2. MCPTUBE_DEFAULT_MODEL environment variable
+        3. API key detection (ANTHROPIC, OPENAI, GOOGLE)
+        4. Default fallback to gpt-4o
+        
+        If OPENAI_BASE_URL is set, prepends 'openai/' prefix to model names
+        to route through the OpenAI-compatible endpoint.
+        """
+        # Check if using OpenAI-compatible endpoint
+        openai_base_url = os.environ.get("OPENAI_BASE_URL")
+        
+        # Check for explicit MCPTUBE_DEFAULT_MODEL env var first
+        default_model_env = os.environ.get("MCPTUBE_DEFAULT_MODEL")
+        if default_model_env:
+            # Prepend 'openai/' prefix if using OpenAI-compatible endpoint
+            if openai_base_url and not default_model_env.startswith("openai/"):
+                model = f"openai/{default_model_env}"
+            else:
+                model = default_model_env
+            logger.info("Using model from MCPTUBE_DEFAULT_MODEL: %s", model)
+            return model
+        
+        # Then check for API keys
         for key, model in self._KEY_TO_MODEL.items():
             if os.environ.get(key):
+                # Prepend 'openai/' prefix if using OpenAI-compatible endpoint
+                if openai_base_url and not model.startswith("openai/"):
+                    model = f"openai/{model}"
                 logger.info("Auto-detected LLM provider: %s → %s", key, model)
                 return model
-        return settings.default_model
+        
+        # Finally fallback to settings.default_model
+        fallback = settings.default_model
+        if openai_base_url and not fallback.startswith("openai/"):
+            fallback = f"openai/{fallback}"
+        return fallback
 
     @staticmethod
     def _parse_tags(response: str) -> list[str]:

--- a/src/mcptube/llm.py
+++ b/src/mcptube/llm.py
@@ -132,17 +132,24 @@ class LLMClient:
         3. API key detection (ANTHROPIC, OPENAI, GOOGLE)
         4. Default fallback to gpt-4o
         
-        If OPENAI_BASE_URL is set, prepends 'openai/' prefix to model names
-        to route through the OpenAI-compatible endpoint.
+        If OPENAI_BASE_URL is set AND OPENAI_API_KEY is present, prepends
+        'openai/' prefix to model names to route through the OpenAI-compatible
+        endpoint. This prevents masking the actual model when using API keys
+        from other cloud providers (Anthropic, Google, etc.) with a custom endpoint.
         """
         # Check if using OpenAI-compatible endpoint
         openai_base_url = os.environ.get("OPENAI_BASE_URL")
+        openai_api_key = os.environ.get("OPENAI_API_KEY")
+        
+        # Only prepend 'openai/' prefix when using an OpenAI-compatible endpoint
+        # This means OPENAI_BASE_URL must be set AND OPENAI_API_KEY must be present
+        use_openai_prefix = openai_base_url is not None and openai_api_key is not None
         
         # Check for explicit MCPTUBE_DEFAULT_MODEL env var first
         default_model_env = os.environ.get("MCPTUBE_DEFAULT_MODEL")
         if default_model_env:
-            # Prepend 'openai/' prefix if using OpenAI-compatible endpoint
-            if openai_base_url and not default_model_env.startswith("openai/"):
+            # Prepend 'openai/' prefix only when using OpenAI-compatible endpoint
+            if use_openai_prefix and not default_model_env.startswith("openai/"):
                 model = f"openai/{default_model_env}"
             else:
                 model = default_model_env
@@ -152,15 +159,16 @@ class LLMClient:
         # Then check for API keys
         for key, model in self._KEY_TO_MODEL.items():
             if os.environ.get(key):
-                # Prepend 'openai/' prefix if using OpenAI-compatible endpoint
-                if openai_base_url and not model.startswith("openai/"):
+                # Prepend 'openai/' prefix only when using OpenAI-compatible endpoint
+                # Don't prepend for non-OpenAI providers even if base_url is set
+                if use_openai_prefix and not model.startswith("openai/"):
                     model = f"openai/{model}"
                 logger.info("Auto-detected LLM provider: %s → %s", key, model)
                 return model
         
         # Finally fallback to settings.default_model
         fallback = settings.default_model
-        if openai_base_url and not fallback.startswith("openai/"):
+        if use_openai_prefix and not fallback.startswith("openai/"):
             fallback = f"openai/{fallback}"
         return fallback
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -25,6 +25,102 @@ class TestDetectModel:
             client = LLMClient()
             assert "gemini" in client.model
 
+    def test_detect_model_with_custom_endpoint_and_openai_key(self):
+        """Test that openai/ prefix is prepended when using OpenAI-compatible endpoint with OpenAI key."""
+        with patch.dict("os.environ", {
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            assert client.model.startswith("openai/")
+
+    def test_detect_model_with_custom_endpoint_and_anthropic_key(self):
+        """Test that openai/ prefix is NOT prepended when using custom endpoint with Anthropic key."""
+        with patch.dict("os.environ", {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            assert not client.model.startswith("openai/")
+            assert "anthropic" in client.model or "claude" in client.model
+
+    def test_detect_model_with_custom_endpoint_and_google_key(self):
+        """Test that openai/ prefix is NOT prepended when using custom endpoint with Google key."""
+        with patch.dict("os.environ", {
+            "GOOGLE_API_KEY": "goog-test",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            assert not client.model.startswith("openai/")
+            assert "gemini" in client.model
+
+    def test_detect_model_with_custom_endpoint_but_no_openai_key(self):
+        """Test that openai/ prefix is NOT prepended when custom endpoint is set but no OpenAI key."""
+        with patch.dict("os.environ", {
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1",
+            "ANTHROPIC_API_KEY": "sk-ant-test"
+        }, clear=True):
+            client = LLMClient()
+            assert not client.model.startswith("openai/")
+
+    def test_detect_model_with_openai_key_but_no_custom_endpoint(self):
+        """Test that model name is NOT prefixed when using OpenAI key without custom endpoint."""
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=True):
+            client = LLMClient()
+            assert not client.model.startswith("openai/")
+
+    def test_detect_model_with_explicit_model_and_custom_endpoint(self):
+        """Test explicit model is prefixed when using OpenAI-compatible endpoint."""
+        with patch.dict("os.environ", {
+            "MCPTUBE_DEFAULT_MODEL": "gpt-3.5-turbo",
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            assert client.model == "openai/gpt-3.5-turbo"
+
+    def test_detect_model_with_explicit_model_and_custom_endpoint_no_openai_key(self):
+        """Test explicit model is NOT prefixed when no OpenAI key is present."""
+        with patch.dict("os.environ", {
+            "MCPTUBE_DEFAULT_MODEL": "gpt-3.5-turbo",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1",
+            "ANTHROPIC_API_KEY": "sk-ant-test"
+        }, clear=True):
+            client = LLMClient()
+            assert client.model == "gpt-3.5-turbo"
+            assert not client.model.startswith("openai/")
+
+    def test_detect_model_with_explicit_model_already_prefixed(self):
+        """Test model already prefixed with openai/ is not double-prefixed."""
+        with patch.dict("os.environ", {
+            "MCPTUBE_DEFAULT_MODEL": "openai/gpt-3.5-turbo",
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            assert client.model == "openai/gpt-3.5-turbo"
+
+    def test_detect_model_constructor_parameter_takes_precedence(self):
+        """Test that constructor model parameter takes precedence over environment."""
+        client = LLMClient(model="custom-model-from-constructor")
+        assert client.model == "custom-model-from-constructor"
+
+    def test_detect_model_fallback_to_settings_default(self):
+        """Test fallback to settings.default_model when no env vars or keys are set."""
+        with patch.dict("os.environ", {}, clear=True):
+            client = LLMClient()
+            assert client.model == "gpt-4o"
+
+    def test_detect_model_with_custom_endpoint_no_keys_no_model(self):
+        """Test behavior with custom endpoint set but no keys or model specified."""
+        with patch.dict("os.environ", {
+            "OPENAI_BASE_URL": "https://custom.endpoint.com/v1"
+        }, clear=True):
+            client = LLMClient()
+            # Should use default_model without prefix since no OpenAI key
+            assert client.model == "gpt-4o"
+            assert not client.model.startswith("openai/")
+
 
 class TestAvailable:
     def test_available_with_key(self):


### PR DESCRIPTION
Update to add the ability to run against a local OpenAI Compatible endpoint (tested with Lemonade server hosted on LAN.)

Setting:
$env:OPENAI_BASE_URL = "http://192.168.50.52:8000/api/v1"
$env:OPENAI_API_KEY = "<APIKey>"
$env:MCPTUBE_DEFAULT_MODEL = "Qwen3.5-35B-A3B-GGUF" 

Successfully lets me use Qwen 3.5 as a backend for the command line functionality.   